### PR TITLE
sympy 1.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - mpmath
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - mpmath >=0.19
     - python
@@ -30,10 +32,105 @@ requirements:
     - antlr-python-runtime >=4.7,<4.8
 
 test:
+  requires:
+    - pip
   commands:
+    - pip check
     - isympy --help
   imports:
     - sympy
+    - sympy.algebras
+    - sympy.assumptions
+    - sympy.assumptions.handlers
+    - sympy.assumptions.predicates
+    - sympy.assumptions.relation
+    - sympy.benchmarks
+    - sympy.calculus
+    - sympy.categories
+    - sympy.codegen
+    - sympy.combinatorics
+    - sympy.concrete
+    - sympy.core
+    - sympy.core.benchmarks
+    - sympy.crypto
+    - sympy.diffgeom
+    - sympy.discrete
+    - sympy.external
+    - sympy.functions
+    - sympy.functions.combinatorial
+    - sympy.functions.elementary
+    - sympy.functions.elementary.benchmarks
+    - sympy.functions.special
+    - sympy.functions.special.benchmarks
+    - sympy.geometry
+    - sympy.holonomic
+    - sympy.integrals
+    - sympy.integrals.benchmarks
+    - sympy.integrals.rubi
+    - sympy.integrals.rubi.parsetools
+    - sympy.integrals.rubi.rubi_tests
+    - sympy.integrals.rubi.rules
+    - sympy.interactive
+    - sympy.liealgebras
+    - sympy.logic
+    - sympy.logic.algorithms
+    - sympy.logic.utilities
+    - sympy.matrices
+    - sympy.matrices.benchmarks
+    - sympy.matrices.expressions
+    - sympy.multipledispatch
+    - sympy.ntheory
+    - sympy.parsing
+    - sympy.parsing.autolev
+    - sympy.parsing.autolev._antlr
+    - sympy.parsing.c
+    - sympy.parsing.fortran
+    - sympy.parsing.latex
+    - sympy.parsing.latex._antlr
+    - sympy.physics
+    - sympy.physics.continuum_mechanics
+    - sympy.physics.control
+    - sympy.physics.hep
+    - sympy.physics.mechanics
+    - sympy.physics.optics
+    - sympy.physics.quantum
+    - sympy.physics.units
+    - sympy.physics.units.definitions
+    - sympy.physics.units.systems
+    - sympy.physics.vector
+    - sympy.plotting
+    - sympy.plotting.intervalmath
+    - sympy.plotting.pygletplot
+    - sympy.polys
+    - sympy.polys.agca
+    - sympy.polys.benchmarks
+    - sympy.polys.domains
+    - sympy.polys.matrices
+    - sympy.printing
+    - sympy.printing.pretty
+    - sympy.sandbox
+    - sympy.series
+    - sympy.series.benchmarks
+    - sympy.sets
+    - sympy.sets.handlers
+    - sympy.simplify
+    - sympy.solvers
+    - sympy.solvers.benchmarks
+    - sympy.solvers.diophantine
+    - sympy.solvers.ode
+    - sympy.stats
+    - sympy.stats.sampling
+    - sympy.strategies
+    - sympy.strategies.branch
+    - sympy.tensor
+    - sympy.tensor.array
+    - sympy.tensor.array.expressions
+    - sympy.testing
+    - sympy.unify
+    - sympy.utilities
+    - sympy.utilities._compilation
+    - sympy.utilities.mathml
+    - sympy.vector
 
 about:
   home: https://sympy.org


### PR DESCRIPTION
Update sympy to 1.9

Category:  anaconda | subcategory:  core | pkg_type:  python
Popularity:  1735962 downloads -  sympy  1.9  Python library for symbolic mathematics
Version change: bump version number from 1.8 to 1.9
  license: BSD-3-Clause
Release date:  Oct 8, 2021
Bug Tracker: new open issues https://github.com/sympy/sympy/issues
Upstream changelog:  many breaking changes https://github.com/sympy/sympy/wiki/release-notes-for-1.9
License file:  https://github.com/sympy/sympy/blob/master/LICENSE
Upstream setup.py:  https://github.com/sympy/sympy/blob/master/setup.py

The package sympy is mentioned inside the packages:
coremltools | quantecon | spyder | yt |

Actions:
1. Add missing packages: `setuptools`, `wheel`
2. Add `pip check` in the test section
3. Add more imports

Result:
- all-succeeded