### PR TITLE
sympy 1.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9" %}
+{% set version = "1.10" %}
 
 package:
   name: sympy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/sympy/sympy-{{ version }}.tar.gz
-  sha256: c7a880e229df96759f955d4f3970d4cabce79f60f5b18830c08b90ce77cd5fdc
+  sha256: 6cf85a5cfe8fff69553e745b05128de6fc8de8f291965c63871c79701dc6efc9
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,26 @@
-{% set version = "1.10" %}
+{% set name = "sympy" %}
+{% set version = "1.10.1" %}
 
 package:
-  name: sympy
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/sympy/sympy-{{ version }}.tar.gz
-  sha256: 6cf85a5cfe8fff69553e745b05128de6fc8de8f291965c63871c79701dc6efc9
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5939eeffdf9e152172601463626c022a2c27e75cf6278de8d401d50c9d58787b
 
 build:
   number: 0
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - isympy = isympy:main
-  skip: true  # [py<36]
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
   host:
     - mpmath
     - pip
+    - pyflakes
     - python
     - setuptools
     - wheel
@@ -29,6 +29,7 @@ requirements:
     - python
     - gmpy2 >=2.0.8   # [python_impl == "cpython" and not win]
   run_constrained:
+    # LaTeX Parser/Lexer
     - antlr-python-runtime >=4.7,<4.8
 
 test:
@@ -134,7 +135,7 @@ test:
 
 about:
   home: https://sympy.org
-  license: BSD-3-Clause
+  license: BSD-3-Clause AND MIT
   license_family: BSD
   license_file: LICENSE
   summary: Python library for symbolic mathematics

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   host:
     - mpmath
     - pip
-    - pyflakes
     - python
     - setuptools
     - wheel


### PR DESCRIPTION
License: https://github.com/sympy/sympy/blob/sympy-1.10.1/LICENSE
Changelog: https://github.com/sympy/sympy/wiki/Release-Notes-for-1.10.1 and https://github.com/sympy/sympy/wiki/Release-Notes-for-1.10
Requirements:
- https://github.com/sympy/sympy#installation
- https://github.com/sympy/sympy#regenerate-experimental-latex-parserlexer
- https://docs.sympy.org/dev/guides/getting_started/install.html
- https://github.com/sympy/sympy/blob/sympy-1.10.1/setup.py

Actions:
1. Skip py<37
2. Remove req/build
3. Update license: add MIT