### PR TITLE
build sympy for 3.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - mpmath >=0.19
     - python
     # gmpy2 brings added performance. It is not yet available for 3.12.
-    - gmpy2 >=2.0.8   # [python_impl == "cpython" and (not win or not py==312)]
+    - gmpy2 >=2.0.8   # [not py==312]
   run_constrained:
     # LaTeX Parser/Lexer
     - antlr-python-runtime >=4.7,<4.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - mpmath >=0.19
     - python
-    - gmpy2 >=2.0.8   # [python_impl == "cpython" and not win]
+    - gmpy2 >=2.0.8   # [python_impl == "cpython" and (not win or not py==312)]
   run_constrained:
     # LaTeX Parser/Lexer
     - antlr-python-runtime >=4.7,<4.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,12 @@ requirements:
   run:
     - mpmath >=0.19
     - python
+    # gmpy2 brings added performance. It is not yet available for 3.12.
     - gmpy2 >=2.0.8   # [python_impl == "cpython" and (not win or not py==312)]
   run_constrained:
     # LaTeX Parser/Lexer
     - antlr-python-runtime >=4.7,<4.8
+    - gmpy2 >=2.0.8
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 
 requirements:
   host:
-    - mpmath 1.2.1
     - pip
     - python
     - setuptools


### PR DESCRIPTION
Changes:
- gmpy2 is optional and not yet released for 3.12

This PR will only build 3.12 packages, hence not increasing the build number.