### PR TITLE
v1.13.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sympy" %}
-{% set version = "1.13.2" %}
+{% set version = "1.13.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/sympy/sympy-{{ version }}.tar.gz
-  sha256: 401449d84d07be9d0c7a46a64bd54fe097667d5e7181bfe67ec777be9e01cb13
+  sha256: b27fd2c6530e0ab39e275fc9b683895367e51d5da91baa8d3d64db2565fec4d9
 
 build:
   number: 0


### PR DESCRIPTION
sympy v1.13.2

**Destination channel:**  defaults

### Links

- [PKG-6395](https://anaconda.atlassian.net/browse/PKG-6395) 
- [Upstream repository](https://github.com/sympy/sympy/tree/sympy-1.13.3)
- [setup.py](https://github.com/sympy/sympy/blob/sympy-1.13.3/setup.py)

### Explanation of changes:

-  Needed to satisfy `- sympy >=1.13.1,!=1.13.2` for pytorch on Windows.
- Update version and SHA


[PKG-6395]: https://anaconda.atlassian.net/browse/PKG-6395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ