### PR TITLE
Rebuild for python 3.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b27fd2c6530e0ab39e275fc9b683895367e51d5da91baa8d3d64db2565fec4d9
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vvv
   entry_points:
@@ -23,14 +23,13 @@ requirements:
     - setuptools
     - wheel
   run:
-    - mpmath >=1.1.0,<1.4
     - python
-    # gmpy2 brings added performance. It is not yet available for 3.12.
-    - gmpy2 >=2.0.8   # [not py==312]
+    - mpmath >=1.1.0
+    # gmpy2 brings added performance. https://github.com/sympy/sympy/blob/1.13.3/doc/src/contributing/dependencies.md#recommended-optional-dependencies
+    - gmpy2
   run_constrained:
-    # LaTeX Parser/Lexer
+    # LaTeX Parser/Lexer. https://github.com/sympy/sympy/blob/1.13.3/doc/src/modules/parsing.rst#runtime-installation
     - antlr-python-runtime >=4.11,<4.12
-    - gmpy2 >=2.0.8
 
 test:
   requires:
@@ -41,7 +40,6 @@ test:
   commands:
     - pip check
     - isympy --help
-    - python -c "import sympy; sympy.test(parallel=True)"
   imports:
     - sympy
     - sympy.algebras

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -5,4 +5,4 @@ from sympy import Rational
 a = Rational(14, 4)
 assert str(a) == '7/2'
 
-sympy.test()
+sympy.test(parallel=True)


### PR DESCRIPTION
sympy 1.13.3 b1

**Destination channel:** defaults

### Links

- [PKG-6307](https://anaconda.atlassian.net/browse/PKG-6307)
- [Upstream repository](https://github.com/sympy/sympy/tree/sympy-1.13.3)
- Relevant dependency PRs:
  - AnacondaRecipes/gmpy2-feedstock#4
  - AnacondaRecipes/mpc-feedstock#3
  - AnacondaRecipes/mpfr-feedstock#4
  - AnacondaRecipes/gmp-feedstock#5

### Explanation of changes:

- Set `mpmath` pinning based on upstream requirements
- Avoid running unit tests twice


[PKG-6307]: https://anaconda.atlassian.net/browse/PKG-6307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ